### PR TITLE
Switch back to normal module instead of extra-data

### DIFF
--- a/org.kicad.KiCad.Library.Packages3D.yml
+++ b/org.kicad.KiCad.Library.Packages3D.yml
@@ -6,26 +6,18 @@ sdk: org.freedesktop.Sdk//20.08
 build-extension: true
 separate-locales: false
 appstream-compose: false
+build-options:
+  prefix: /app/extensions/Library/Packages3D
 modules:
 - name: kicad-packages3D
-  buildsystem: simple
-  build-commands:
-  - install -D apply_extra $FLATPAK_DEST/bin/apply_extra
+  buildsystem: cmake-ninja
   post-install:
   - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.kicad.KiCad.Library.Packages3D.metainfo.xml
   - appstream-compose --basename=org.kicad.KiCad.Library.Packages3D --prefix=${FLATPAK_DEST}
     --origin=flatpak org.kicad.KiCad.Library.Packages3D
   sources:
-  - type: script
-    commands:
-    - tar xzf kicad-packages3d.tar.gz --strip-components 1 --wildcards "*.step" "*.wrl"
-    - rm -rf kicad-packages3d.tar.gz
-    dest-filename: apply_extra
-  - type: extra-data
-    filename: kicad-packages3d.tar.gz
+  - type: archive
     url: https://gitlab.com/kicad/libraries/kicad-packages3d/-/archive/5.1.9/kicad-packages3d-5.1.9.tar.gz
     sha256: 6e3bd169eef2852b88a36f2a7a8156c7026830da2f6c319d8f35d60c87a0be48
-    size: 942968696
-    installed-size: 5551591622
   - type: file
     path: org.kicad.KiCad.Library.Packages3D.metainfo.xml


### PR DESCRIPTION
This is meant to investigate build issues with aarch64.

After increasing the build timeout to 40 minutes, this extension builds successfully again, and shall thus be merged. The benefit for end-users is the faster delta download on extension update.